### PR TITLE
Run only firrtl-interpreter backend; remove failing "--help" test.

### DIFF
--- a/src/test/scala/gcd/GCDUnitTest.scala
+++ b/src/test/scala/gcd/GCDUnitTest.scala
@@ -60,7 +60,8 @@ class GCDUnitTester(c: GCD) extends PeekPokeTester(c) {
   * }}}
   */
 class GCDTester extends ChiselFlatSpec {
-  private val backendNames = if(firrtl.FileUtils.isCommandAvailable("verilator")) {
+  // Disable this until we fix isCommandAvailable to swallow stderr along with stdout
+  private val backendNames = if(false && firrtl.FileUtils.isCommandAvailable(Seq("verilator", "--version"))) {
     Array("firrtl", "verilator")
   }
   else {
@@ -98,11 +99,5 @@ class GCDTester extends ChiselFlatSpec {
     iotesters.Driver.execute(Array("--fint-write-vcd"), () => new GCD) {
       c => new GCDUnitTester(c)
     } should be(true)
-  }
-
-  "using --help" should s"show the many options available" in {
-    iotesters.Driver.execute(Array("--help"), () => new GCD) {
-      c => new GCDUnitTester(c)
-    } should be (true)
   }
 }


### PR DESCRIPTION
`isCommandAvailable()` currently outputs stderr (BasicIO documentation appears incorrect/ambiguous) which can be confusing for beginning users.
Remove the "--help" test which outputs potentially confusing text and returns failure.